### PR TITLE
Feature/GitHub oauth and cache dir config

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,5 @@
 composer_version: 1.6.5
-composer_checksum: sha384:544e09ee996cdf60ece3804abc52599c22b1f40f4323403c44d44fdfdd586475ca9813a858088ffbc1f233e9b180f061
+composer_checksum: sha384:30414d521f49a9f7260b9d1ef982fef7aee1b4b00aa18c1a232fb059eeb79883431ce2d6c4bf5e3a5b91c718904d7010
+composer_user: nobody
+composer_app_path: /var/www
+composer_cache_dir: /tmp/composer

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -6,7 +6,8 @@
     php_enabled: yes
     php_version: 7.2
 
-    composer_testing: yes
+    composer_user: vagrant
+    composer_app_path: /home/vagrant
 
   roles:
     - role: blunix.role-php

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -9,7 +9,7 @@ COMPOSER_VERSION = '1.6.5'
 
 
 def test_composer(host):
-    cmd = host.run('php composer.phar')
+    cmd = host.run('composer')
 
     assert cmd.rc == 0
 

--- a/tasks/composer.yml
+++ b/tasks/composer.yml
@@ -7,3 +7,13 @@
   loop_control:
     loop_var: composer_install_item
   tags: install
+
+- name: Including distro-specific configure tasks
+  include_tasks: "{{ composer_configure_item }}"
+  with_first_found:
+    - configure/{{ ansible_distribution }}.{{ ansible_lsb.codename }}.yml
+    - configure/{{ ansible_distribution }}.yml
+    - configure/default.yml
+  loop_control:
+    loop_var: composer_configure_item
+  tags: configure

--- a/tasks/configure/default.yml
+++ b/tasks/configure/default.yml
@@ -1,0 +1,9 @@
+- name: Configuring Composer's cache folder
+  become: yes
+  become_user: "{{ composer_user }}"
+  composer:
+    command: config
+    global_command: yes
+    working_dir: "{{ composer_app_path }}"
+    arguments: cache-dir {{ composer_cache_dir }}
+  changed_when: no  # idempotence fails

--- a/tasks/install/default.yml
+++ b/tasks/install/default.yml
@@ -1,18 +1,8 @@
-- name: Downloading composer-setup.php
+- name: Downloading composer.phar
   get_url:
-    url: "https://getcomposer.org/installer"
-    dest: "/composer-setup.php"
+    url: "https://getcomposer.org/download/{{ composer_version }}/composer.phar"
+    dest: "/usr/local/bin/composer"
     checksum: "{{ composer_checksum | default(None) }}"
     owner: root
     group: root
     mode: 0755
-
-- name: Installing composer-{{ composer_version }}
-  shell: php /composer-setup.php --quiet --version={{ composer_version }}
-  changed_when: no
-
-- name: Removing composer-setup.php
-  when: composer_testing is not defined or not composer_testing
-  file:
-    path: ~/composer-setup.php
-    state: absent


### PR DESCRIPTION
This PR:

- downloads the `composer.phar` directly to `/usr/local/bin/composer` as `role-php` does
- adds support for configuring Composer's cache directory